### PR TITLE
chore: add PR/issue templates and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,19 @@
+---
+name: Bug Report
+about: Report a bug
+title: "[BUG] "
+labels: bug
+---
+
+## Description
+<!-- What happened? -->
+
+## Steps to Reproduce
+1. 
+
+## Expected Behavior
+<!-- What should have happened? -->
+
+## Environment
+- OS: 
+- Version: 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature Request
+about: Suggest a feature
+title: "[FEATURE] "
+labels: enhancement
+---
+
+## Description
+<!-- What feature do you want? -->
+
+## Use Case
+<!-- Why do you need this? -->
+
+## Proposed Solution
+<!-- How should it work? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+<!-- What does this PR do? -->
+
+## Changes
+- 
+
+## Testing
+- [ ] Tests pass locally
+- [ ] No new warnings
+
+## Checklist
+- [ ] Code follows project style
+- [ ] Self-reviewed
+- [ ] No secrets committed


### PR DESCRIPTION
Adds standardized repository templates:
- PR template (`.github/PULL_REQUEST_TEMPLATE.md`)
- Bug report issue template (`.github/ISSUE_TEMPLATE/bug_report.md`)
- Feature request issue template (`.github/ISSUE_TEMPLATE/feature_request.md`)
- EditorConfig (`.editorconfig`) for consistent coding style