### PR TITLE
chore: add CI/security status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Security](https://github.com/basel5001/udapeople-cicd/actions/workflows/security.yml/badge.svg)
+![CI](https://github.com/basel5001/udapeople-cicd/actions/workflows/ci.yml/badge.svg)
 
 ## Give your Application Auto-Deploy Superpowers
  


### PR DESCRIPTION
Adds Security and CI workflow status badges to the top of the README.